### PR TITLE
configurable metrics support

### DIFF
--- a/ops-log-k8s-mutating-wh/manifest-examples/02-deployment.yaml
+++ b/ops-log-k8s-mutating-wh/manifest-examples/02-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: prysmwebhook
-        image: ghcr.io/cobaltcore-dev/prysm-wh:v1.2.3
+        image: ghcr.io/cobaltcore-dev/prysm-webhook:sha-5eb62ab
         ports:
         - containerPort: 8443
         volumeMounts:
@@ -25,7 +25,7 @@ spec:
           readOnly: true
         env:
         - name: SIDECAR_IMAGE
-          value: "ghcr.io/cobaltcore-dev/prysm:v1.2.3"
+          value: "ghcr.io/cobaltcore-dev/prysm:sha-5eb62ab"
         imagePullPolicy: Always
       volumes:
       - name: certs

--- a/ops-log-k8s-mutating-wh/manifest-examples/05-prysm-sidecar-secret.yaml
+++ b/ops-log-k8s-mutating-wh/manifest-examples/05-prysm-sidecar-secret.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rgw-sidecar-env
+  namespace: rook-ceph
+type: Opaque
+stringData:
+  LOG_FILE_PATH: "/var/log/ceph/ops-log.log"
+  SOCKET_PATH: ""
+  NATS_URL: "nats://nats.nats.svc.cluster.local:4222"
+  NATS_SUBJECT: "rgw.s3.ops"
+  NATS_METRICS_SUBJECT: "rgw.s3.ops.aggregated.metrics"
+  LOG_TO_STDOUT: "false"
+  LOG_RETENTION_DAYS: "2"
+  MAX_LOG_FILE_SIZE: "10"
+  PROMETHEUS_PORT: "9090"
+  POD_NAME: "dummy-pod"
+  IGNORE_ANONYMOUS_REQUESTS: "true"
+
+  TRACK_REQUESTS_BY_IP: "true"
+  TRACK_BYTES_SENT_BY_IP: "true"
+  TRACK_BYTES_RECEIVED_BY_IP: "true"
+  TRACK_ERRORS_BY_IP: "true"
+  TRACK_ERRORS_BY_USER: "true"
+  TRACK_REQUESTS_BY_METHOD: "true"
+  TRACK_REQUESTS_BY_OPERATION: "true"
+  TRACK_REQUESTS_BY_STATUS: "true"
+  TRACK_REQUESTS_BY_BUCKET: "true"
+  TRACK_REQUESTS_BY_USER: "true"
+  TRACK_REQUESTS_BY_TENANT: "false"
+  TRACK_ERRORS_BY_BUCKET: "false"
+  TRACK_ERRORS_BY_STATUS: "false"
+  TRACK_LATENCY_BY_USER: "false"
+  TRACK_LATENCY_BY_BUCKET: "false"
+  TRACK_LATENCY_BY_TENANT: "false"

--- a/pkg/producers/opslog/README.md
+++ b/pkg/producers/opslog/README.md
@@ -36,7 +36,7 @@ prysm local-producer ops-log [flags]
 - `--prometheus` - Enable Prometheus metrics.
 - `--prometheus-port 8080` - Port for Prometheus metrics.
 - `--ignore-anonymous-requests` - Ignore anonymous requests in metrics.
-- `--rotate-log-on-start` - Rotate log on start to avoid re-processing existing data.
+- `--truncate-log-on-start` - Rotate log on start to avoid re-processing existing data.
 
 ### Environment Variables
 
@@ -52,7 +52,7 @@ prysm local-producer ops-log [flags]
 | `MAX_LOG_FILE_SIZE`          | Maximum log file size before rotation (in MB).  |
 | `PROMETHEUS_PORT`            | Port for Prometheus metrics.                    |
 | `IGNORE_ANONYMOUS_REQUESTS`  | Ignore anonymous requests in metrics.           |
-| `ROTATE_LOG_ON_START`        | Whether to rotate the log file on startup.      |
+| `TRUNCATE_LOG_ON_START`        | Whether to rotate the log file on startup.      |
 
 
 #### Metric Toggle Environment Variables:

--- a/pkg/producers/opslog/config.go
+++ b/pkg/producers/opslog/config.go
@@ -6,6 +6,7 @@ package opslog
 
 type OpsLogConfig struct {
 	LogFilePath             string
+	TruncateLogOnStart      bool
 	SocketPath              string
 	NatsURL                 string
 	NatsSubject             string
@@ -18,4 +19,37 @@ type OpsLogConfig struct {
 	PrometheusPort          int
 	PodName                 string
 	IgnoreAnonymousRequests bool
+	MetricsConfig           MetricsConfig
+}
+
+type MetricsConfig struct {
+	// Request Tracking
+	TrackRequestsByIP        bool // High cardinality, should be optional
+	TrackRequestsByUser      bool
+	TrackRequestsByBucket    bool
+	TrackRequestsByMethod    bool
+	TrackRequestsByOperation bool
+	TrackRequestsByStatus    bool
+	TrackRequestsByTenant    bool // Potentially useful for multi-tenant insights
+
+	// Data Usage Tracking
+	TrackBytesSentByIP         bool // High cardinality, should be optional
+	TrackBytesReceivedByIP     bool // High cardinality, should be optional
+	TrackBytesSentByUser       bool
+	TrackBytesReceivedByUser   bool
+	TrackBytesSentByBucket     bool
+	TrackBytesReceivedByBucket bool
+
+	// Error Tracking
+	TrackErrorsByIP     bool // High cardinality, should be optional
+	TrackErrorsByUser   bool
+	TrackErrorsByBucket bool
+	TrackErrorsByStatus bool
+
+	// Latency & Performance
+	TrackLatencyByUser            bool // Fine-grained user tracking
+	TrackLatencyByBucket          bool // Latency grouped per bucket
+	TrackLatencyByTenant          bool // Aggregated latency by tenant
+	TrackLatencyByMethod          bool // Per HTTP method
+	TrackLatencyByBucketAndMethod bool // Combination of both (detailed)
 }

--- a/pkg/producers/opslog/prometheus.go
+++ b/pkg/producers/opslog/prometheus.go
@@ -22,7 +22,7 @@ var (
 			Name: "radosgw_total_requests",
 			Help: "Total number of requests processed",
 		},
-		[]string{"pod", "user", "tenant", "bucket"},
+		[]string{"pod", "user", "tenant", "bucket", "method", "http_status"},
 	)
 
 	// Requests grouped by HTTP method (GET, PUT, POST, DELETE, etc.)
@@ -34,7 +34,7 @@ var (
 		[]string{"pod", "user", "tenant", "bucket", "method"},
 	)
 
-	// Requests grouped by operation (GET, PUT, DELETE, etc.)
+	// Requests grouped by operation
 	requestsByOperationCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "radosgw_requests_by_operation",
@@ -76,34 +76,7 @@ var (
 			Name: "radosgw_errors_total",
 			Help: "Total number of errors",
 		},
-		[]string{"pod", "user", "tenant", "bucket"},
-	)
-
-	// Minimum request latency (seconds) per user and bucket
-	latencyMinGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "radosgw_latency_min_seconds",
-			Help: "Minimum request latency in seconds",
-		},
-		[]string{"pod", "user", "tenant", "bucket"},
-	)
-
-	// Maximum request latency (seconds) per user and bucket
-	latencyMaxGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "radosgw_latency_max_seconds",
-			Help: "Maximum request latency in seconds",
-		},
-		[]string{"pod", "user", "tenant", "bucket"},
-	)
-
-	// Average request latency (seconds) per user and bucket
-	latencyAvgGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "radosgw_latency_avg_seconds",
-			Help: "Average request latency in seconds",
-		},
-		[]string{"pod", "user", "tenant", "bucket"},
+		[]string{"pod", "user", "tenant", "bucket", "http_status"},
 	)
 
 	requestsByIPGauge = prometheus.NewGaugeVec(
@@ -146,332 +119,588 @@ var (
 		},
 		[]string{"pod", "bucket", "ip", "http_status"},
 	)
+
+	// Histogram for request duration
+	requestsDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "radosgw_requests_duration",
+			Help:    "Histogram for request latencies",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"user", "tenant", "bucket", "method"},
+		// []string{"pod", "user", "tenant", "bucket", "method"},
+	)
 )
 
-func init() {
-	// Register the Prometheus metrics
+func initPrometheusSettings(metricsConfig *MetricsConfig) {
+	// Register core Prometheus metrics
 	prometheus.MustRegister(totalRequestsCounter)
-	prometheus.MustRegister(requestsByMethodCounter)
-	prometheus.MustRegister(requestsByOperationCounter)
-	prometheus.MustRegister(requestsByStatusCodeCounter)
-	prometheus.MustRegister(bytesSentCounter)
-	prometheus.MustRegister(bytesReceivedCounter)
-	prometheus.MustRegister(errorsCounter)
-	prometheus.MustRegister(latencyMinGauge)
-	prometheus.MustRegister(latencyMaxGauge)
-	prometheus.MustRegister(latencyAvgGauge)
-	prometheus.MustRegister(requestsByIPGauge)
-	prometheus.MustRegister(bytesSentByIPGauge)
-	prometheus.MustRegister(bytesReceivedByIPGauge)
-	prometheus.MustRegister(httpErrorsByUserCounter)
-	prometheus.MustRegister(httpErrorsByIPCounter)
+
+	// Conditional registrations based on config
+	if metricsConfig.TrackRequestsByMethod {
+		prometheus.MustRegister(requestsByMethodCounter)
+	}
+
+	if metricsConfig.TrackRequestsByOperation {
+		prometheus.MustRegister(requestsByOperationCounter)
+	}
+
+	if metricsConfig.TrackRequestsByStatus {
+		prometheus.MustRegister(requestsByStatusCodeCounter)
+	}
+
+	if metricsConfig.TrackBytesSentByUser || metricsConfig.TrackBytesSentByBucket {
+		prometheus.MustRegister(bytesSentCounter)
+	}
+
+	if metricsConfig.TrackBytesReceivedByUser || metricsConfig.TrackBytesReceivedByBucket {
+		prometheus.MustRegister(bytesReceivedCounter)
+	}
+
+	if metricsConfig.TrackErrorsByUser || metricsConfig.TrackErrorsByIP {
+		prometheus.MustRegister(errorsCounter)
+	}
+
+	// Conditional IP tracking
+	if metricsConfig.TrackRequestsByIP {
+		prometheus.MustRegister(requestsByIPGauge)
+	}
+	if metricsConfig.TrackBytesSentByIP {
+		prometheus.MustRegister(bytesSentByIPGauge)
+	}
+	if metricsConfig.TrackBytesReceivedByIP {
+		prometheus.MustRegister(bytesReceivedByIPGauge)
+	}
+
+	// Conditional error tracking
+	if metricsConfig.TrackErrorsByUser {
+		prometheus.MustRegister(httpErrorsByUserCounter)
+	}
+
+	if metricsConfig.TrackErrorsByIP {
+		prometheus.MustRegister(httpErrorsByIPCounter)
+	}
+
+	prometheus.MustRegister(requestsDurationHistogram)
 }
 
 // PublishToPrometheus updates Prometheus metrics from aggregated data
 func PublishToPrometheus(metrics *Metrics, cfg OpsLogConfig) {
-	// Total requests grouped by user and bucket
-	metrics.RequestsByUser.Range(func(user, requestCount interface{}) bool {
-		userStr, tenantStr := extractUserAndTenant(user.(string))
-		rqCount := float64(requestCount.(*atomic.Uint64).Load())
+	metricsConfig := cfg.MetricsConfig
 
-		totalRequestsCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   userStr,
-			"tenant": tenantStr,
-			"bucket": "all",
-		}).Add(rqCount)
-		return true
-	})
+	if metricsConfig.TrackRequestsByUser {
+		// Total requests grouped by user, bucket, method, and status
+		metrics.RequestsByUser.Range(func(key, requestCount any) bool {
+			parts := strings.Split(key.(string), "|")
+			if len(parts) != 4 { // Expecting user | bucket | method | http_status
+				log.Warn().Msgf("Invalid key format in RequestsByUser: %v", key)
+				return true
+			}
 
-	metrics.RequestsByBucket.Range(func(bucket, requestCount interface{}) bool {
-		bucketStr := bucket.(string)
-		rqCount := float64(requestCount.(*atomic.Uint64).Load())
+			user, bucket, method, httpStatus := parts[0], parts[1], parts[2], parts[3]
+			userStr, tenantStr := extractUserAndTenant(user)
+			rqCount := float64(requestCount.(*atomic.Uint64).Load())
 
-		totalRequestsCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   "all",
-			"tenant": "all",
-			"bucket": bucketStr,
-		}).Add(rqCount)
-		return true
-	})
-
-	// Requests per HTTP Method (GET, PUT, DELETE) grouped by User & Bucket
-	metrics.RequestsByMethod.Range(func(key, count interface{}) bool {
-		// Key format: "user|bucket|method"
-		parts := strings.Split(key.(string), "|")
-		user, bucket, method := parts[0], parts[1], parts[2]
-		userStr, tenantStr := extractUserAndTenant(user)
-		requestCount := float64(count.(*atomic.Uint64).Load())
-
-		requestsByMethodCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   userStr,
-			"tenant": tenantStr,
-			"bucket": bucket,
-			"method": method,
-		}).Add(requestCount)
-
-		return true
-	})
-
-	// Requests per Operation (Grouped by User & Bucket)
-	metrics.RequestsByOperation.Range(func(key, count interface{}) bool {
-		// Key format: "user|bucket|operation|method"
-		parts := strings.Split(key.(string), "|")
-		user, bucket, operation, method := parts[0], parts[1], parts[2], parts[3]
-		userStr, tenantStr := extractUserAndTenant(user)
-		requestCount := float64(count.(*atomic.Uint64).Load())
-
-		requestsByOperationCounter.With(prometheus.Labels{
-			"pod":       cfg.PodName,
-			"user":      userStr,
-			"tenant":    tenantStr,
-			"bucket":    bucket,
-			"operation": operation,
-			"method":    method,
-		}).Add(requestCount)
-
-		return true
-	})
-
-	// Requests per Status Code (Grouped by User & Bucket)
-	metrics.RequestsByStatusCode.Range(func(status, count interface{}) bool {
-		statusStr := status.(string)
-		requestCount := float64(count.(*atomic.Uint64).Load())
-
-		requestsByStatusCodeCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   "all",
-			"tenant": "all",
-			"bucket": "all",
-			"status": statusStr,
-		}).Add(requestCount)
-
-		return true
-	})
-
-	// Bytes Sent & Received per User & Bucket
-	metrics.BytesSentByUser.Range(func(user, bytes interface{}) bool {
-		userStr, tenantStr := extractUserAndTenant(user.(string))
-		totalBytes := float64(bytes.(*atomic.Uint64).Load())
-
-		bytesSentCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   userStr,
-			"tenant": tenantStr,
-			"bucket": "all",
-		}).Add(totalBytes)
-		return true
-	})
-
-	metrics.BytesSentByBucket.Range(func(bucket, bytes interface{}) bool {
-		bucketStr := bucket.(string)
-		totalBytes := float64(bytes.(*atomic.Uint64).Load())
-
-		bytesSentCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   "all",
-			"tenant": "all",
-			"bucket": bucketStr,
-		}).Add(totalBytes)
-		return true
-	})
-
-	metrics.BytesReceivedByUser.Range(func(user, bytes interface{}) bool {
-		userStr, tenantStr := extractUserAndTenant(user.(string))
-		totalBytes := float64(bytes.(*atomic.Uint64).Load())
-
-		bytesReceivedCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   userStr,
-			"tenant": tenantStr,
-			"bucket": "all",
-		}).Add(totalBytes)
-		return true
-	})
-
-	metrics.BytesReceivedByBucket.Range(func(bucket, bytes interface{}) bool {
-		bucketStr := bucket.(string)
-		totalBytes := float64(bytes.(*atomic.Uint64).Load())
-
-		bytesReceivedCounter.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   "all",
-			"tenant": "all",
-			"bucket": bucketStr,
-		}).Add(totalBytes)
-		return true
-	})
-
-	// Iterate over users and publish their specific error counts
-	metrics.ErrorsByUser.Range(func(user, count interface{}) bool {
-		userStr, tenantStr := extractUserAndTenant(user.(string))
-		if atomicPtr, ok := count.(*atomic.Uint64); ok {
-			errorCount := atomicPtr.Load()
-			errorsCounter.With(prometheus.Labels{
-				"pod":    cfg.PodName,
-				"user":   userStr,
-				"tenant": tenantStr,
-				"bucket": "all",
-			}).Add(float64(errorCount))
-		} else {
-			fmt.Printf("Warning: Failed to cast error count for user %s\n", userStr)
-		}
-		return true
-	})
-
-	// Publish min latency
-	metrics.LatencyMinByUser.Range(func(user, latency interface{}) bool {
-		userStr, tenantStr := extractUserAndTenant(user.(string))
-		if atomicPtr, ok := latency.(*atomic.Uint64); ok {
-			latencyMin := float64(atomicPtr.Load()) / 1000.0
-			latencyMinGauge.With(prometheus.Labels{
-				"pod":    cfg.PodName,
-				"user":   userStr,
-				"tenant": tenantStr,
-				"bucket": "all",
-			}).Set(latencyMin)
-		}
-		return true
-	})
-
-	// Publish max latency
-	metrics.LatencyMaxByUser.Range(func(user, latency interface{}) bool {
-		userStr, tenantStr := extractUserAndTenant(user.(string))
-		if atomicPtr, ok := latency.(*atomic.Uint64); ok {
-			latencyMax := float64(atomicPtr.Load()) / 1000.0
-			latencyMaxGauge.With(prometheus.Labels{
-				"pod":    cfg.PodName,
-				"user":   userStr,
-				"tenant": tenantStr,
-				"bucket": "all",
-			}).Set(latencyMax)
-		}
-		return true
-	})
-
-	// Publish average latency
-	latencyCount := metrics.LatencyCount.Load()
-	if latencyCount > 0 {
-		avgLatency := float64(metrics.LatencySum.Load()) / float64(latencyCount) / 1000.0 // Convert ms to sec
-		latencyAvgGauge.With(prometheus.Labels{
-			"pod":    cfg.PodName,
-			"user":   "all",
-			"tenant": "all",
-			"bucket": "all",
-		}).Set(avgLatency)
-	}
-
-	// Publish requests per IP & User
-	metrics.RequestsByIP.Range(func(key, count interface{}) bool {
-		keyStr := key.(string)
-		parts := strings.Split(keyStr, "|")
-		user, ip := parts[0], parts[1]
-		userStr, tenantStr := extractUserAndTenant(user)
-
-		if atomicPtr, ok := count.(*atomic.Uint64); ok {
-			requestCount := atomicPtr.Load()
-			requestsByIPGauge.With(prometheus.Labels{
-				"pod":    cfg.PodName,
-				"user":   userStr,
-				"tenant": tenantStr,
-				"ip":     ip,
-			}).Set(float64(requestCount))
-		}
-		return true
-	})
-
-	// Publish bytes sent per IP & User
-	metrics.BytesSentByIP.Range(func(key, bytesSent interface{}) bool {
-		keyStr := key.(string)
-		parts := strings.Split(keyStr, "|")
-		user, ip := parts[0], parts[1]
-		userStr, tenantStr := extractUserAndTenant(user)
-
-		if atomicPtr, ok := bytesSent.(*atomic.Uint64); ok {
-			totalBytesSent := atomicPtr.Load()
-			bytesSentByIPGauge.With(prometheus.Labels{
-				"pod":    cfg.PodName,
-				"user":   userStr,
-				"tenant": tenantStr,
-				"ip":     ip,
-			}).Set(float64(totalBytesSent))
-		}
-		return true
-	})
-
-	// Publish bytes received per IP & User
-	metrics.BytesReceivedByIP.Range(func(key, bytesReceived interface{}) bool {
-		keyStr := key.(string)
-		parts := strings.Split(keyStr, "|")
-		user, ip := parts[0], parts[1]
-		userStr, tenantStr := extractUserAndTenant(user)
-
-		if atomicPtr, ok := bytesReceived.(*atomic.Uint64); ok {
-			totalBytesReceived := atomicPtr.Load()
-			bytesReceivedByIPGauge.With(prometheus.Labels{
-				"pod":    cfg.PodName,
-				"user":   userStr,
-				"tenant": tenantStr,
-				"ip":     ip,
-			}).Set(float64(totalBytesReceived))
-		}
-		return true
-	})
-
-	// Publish HTTP errors per User & Bucket
-	metrics.ErrorsByUserAndBucket.Range(func(key, count interface{}) bool {
-		keyStr := key.(string)
-		parts := strings.Split(keyStr, "|")
-		user, bucket, status := parts[0], parts[1], parts[2]
-		userStr, tenantStr := extractUserAndTenant(user)
-
-		// Exclude HTTP status codes in the 2xx range
-		if strings.HasPrefix(status, "2") {
-			return true
-		}
-
-		if atomicPtr, ok := count.(*atomic.Uint64); ok {
-			errorCount := atomicPtr.Load()
-			httpErrorsByUserCounter.With(prometheus.Labels{
+			// Full request count per user, grouped by method & status
+			totalRequestsCounter.With(prometheus.Labels{
 				"pod":         cfg.PodName,
 				"user":        userStr,
 				"tenant":      tenantStr,
 				"bucket":      bucket,
+				"method":      method,
+				"http_status": httpStatus,
+			}).Add(rqCount)
+
+			// Aggregated per bucket (all methods, but status-specific)
+			totalRequestsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        userStr,
+				"tenant":      tenantStr,
+				"bucket":      bucket,
+				"method":      "all",
+				"http_status": httpStatus,
+			}).Add(rqCount)
+
+			// Fully aggregated per bucket (all methods, all statuses)
+			totalRequestsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        userStr,
+				"tenant":      tenantStr,
+				"bucket":      bucket,
+				"method":      "all",
+				"http_status": "all",
+			}).Add(rqCount)
+
+			// Fully aggregated per user (all buckets, methods, and statuses)
+			totalRequestsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        userStr,
+				"tenant":      tenantStr,
+				"bucket":      "all",
+				"method":      "all",
+				"http_status": "all",
+			}).Add(rqCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackRequestsByTenant {
+		metrics.RequestsByUser.Range(func(key, requestCount any) bool {
+			parts := strings.Split(key.(string), "|")
+			if len(parts) != 4 {
+				log.Warn().Msgf("Invalid key format in RequestsByUser: %v", key)
+				return true
+			}
+			user := parts[0]
+			_, tenantStr := extractUserAndTenant(user)
+			rqCount := float64(requestCount.(*atomic.Uint64).Load())
+
+			// Track per-tenant request count
+			totalRequestsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        "all",
+				"tenant":      tenantStr,
+				"bucket":      "all",
+				"method":      "all",
+				"http_status": "all",
+			}).Add(rqCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackRequestsByBucket {
+		metrics.RequestsByBucket.Range(func(key, requestCount any) bool {
+			parts := strings.Split(key.(string), "|")
+			if len(parts) != 3 {
+				log.Warn().Msgf("Invalid key format in RequestsByBucket: %v", key)
+				return true
+			}
+
+			bucket, method, httpStatus := parts[0], parts[1], parts[2]
+			rqCount := float64(requestCount.(*atomic.Uint64).Load())
+
+			// Full request count per bucket, grouped by method & status
+			totalRequestsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        "all",
+				"tenant":      "all",
+				"bucket":      bucket,
+				"method":      method,
+				"http_status": httpStatus,
+			}).Add(rqCount)
+
+			// Aggregate version per bucket (all methods, but status-specific)
+			totalRequestsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        "all",
+				"tenant":      "all",
+				"bucket":      bucket,
+				"method":      "all",
+				"http_status": httpStatus,
+			}).Add(rqCount)
+
+			// Fully aggregated request count (all methods, all statuses)
+			totalRequestsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        "all",
+				"tenant":      "all",
+				"bucket":      bucket,
+				"method":      "all",
+				"http_status": "all",
+			}).Add(rqCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackRequestsByMethod {
+		// Requests per HTTP Method (GET, PUT, DELETE) grouped by User & Bucket
+		metrics.RequestsByMethod.Range(func(key, count any) bool {
+			// Key format: "user|bucket|method"
+			parts := strings.Split(key.(string), "|")
+			user, bucket, method := parts[0], parts[1], parts[2]
+			userStr, tenantStr := extractUserAndTenant(user)
+			requestCount := float64(count.(*atomic.Uint64).Load())
+
+			requestsByMethodCounter.With(prometheus.Labels{
+				"pod":    cfg.PodName,
+				"user":   userStr,
+				"tenant": tenantStr,
+				"bucket": bucket,
+				"method": method,
+			}).Add(requestCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackRequestsByOperation {
+		// Requests per Operation (Grouped by User & Bucket)
+		metrics.RequestsByOperation.Range(func(key, count any) bool {
+			// Key format: "user|bucket|operation|method"
+			parts := strings.Split(key.(string), "|")
+			user, bucket, operation, method := parts[0], parts[1], parts[2], parts[3]
+			userStr, tenantStr := extractUserAndTenant(user)
+			requestCount := float64(count.(*atomic.Uint64).Load())
+
+			requestsByOperationCounter.With(prometheus.Labels{
+				"pod":       cfg.PodName,
+				"user":      userStr,
+				"tenant":    tenantStr,
+				"bucket":    bucket,
+				"operation": operation,
+				"method":    method,
+			}).Add(requestCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackRequestsByStatus {
+		// Requests per Status Code (Grouped by User & Bucket)
+		metrics.RequestsByStatusCode.Range(func(status, count any) bool {
+			statusStr := status.(string)
+			requestCount := float64(count.(*atomic.Uint64).Load())
+
+			requestsByStatusCodeCounter.With(prometheus.Labels{
+				"pod":    cfg.PodName,
+				"user":   "all",
+				"tenant": "all",
+				"bucket": "all",
+				"status": statusStr,
+			}).Add(requestCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackBytesSentByBucket {
+		metrics.BytesSentByBucket.Range(func(bucket, bytes any) bool {
+			bucketStr := bucket.(string)
+			totalBytes := float64(bytes.(*atomic.Uint64).Load())
+
+			bytesSentCounter.With(prometheus.Labels{
+				"pod":    cfg.PodName,
+				"user":   "all",
+				"tenant": "all",
+				"bucket": bucketStr,
+			}).Add(totalBytes)
+			return true
+		})
+	}
+
+	if metricsConfig.TrackBytesSentByUser {
+		metrics.BytesSentByUser.Range(func(user, bytes any) bool {
+			userStr, tenantStr := extractUserAndTenant(user.(string))
+			totalBytes := float64(bytes.(*atomic.Uint64).Load())
+
+			bytesSentCounter.With(prometheus.Labels{
+				"pod":    cfg.PodName,
+				"user":   userStr,
+				"tenant": tenantStr,
+				"bucket": "all",
+			}).Add(totalBytes)
+			return true
+		})
+	}
+
+	if metricsConfig.TrackBytesReceivedByUser {
+		metrics.BytesReceivedByUser.Range(func(user, bytes any) bool {
+			userStr, tenantStr := extractUserAndTenant(user.(string))
+			totalBytes := float64(bytes.(*atomic.Uint64).Load())
+
+			bytesReceivedCounter.With(prometheus.Labels{
+				"pod":    cfg.PodName,
+				"user":   userStr,
+				"tenant": tenantStr,
+				"bucket": "all",
+			}).Add(totalBytes)
+			return true
+		})
+	}
+
+	if metricsConfig.TrackBytesReceivedByBucket {
+		metrics.BytesReceivedByBucket.Range(func(bucket, bytes any) bool {
+			bucketStr := bucket.(string)
+			totalBytes := float64(bytes.(*atomic.Uint64).Load())
+
+			bytesReceivedCounter.With(prometheus.Labels{
+				"pod":    cfg.PodName,
+				"user":   "all",
+				"tenant": "all",
+				"bucket": bucketStr,
+			}).Add(totalBytes)
+			return true
+		})
+	}
+
+	if metricsConfig.TrackErrorsByUser {
+		// Iterate over users and publish their specific error counts
+		metrics.ErrorsByUser.Range(func(user, count any) bool {
+			userStr, tenantStr := extractUserAndTenant(user.(string))
+			if atomicPtr, ok := count.(*atomic.Uint64); ok {
+				errorCount := atomicPtr.Load()
+				errorsCounter.With(prometheus.Labels{
+					"pod":         cfg.PodName,
+					"user":        userStr,
+					"tenant":      tenantStr,
+					"bucket":      "all",
+					"http_status": "all",
+				}).Add(float64(errorCount))
+			} else {
+				fmt.Printf("Warning: Failed to cast error count for user %s\n", userStr)
+			}
+			return true
+		})
+	}
+
+	if metricsConfig.TrackRequestsByIP {
+		// Publish requests per IP & User
+		metrics.RequestsByIP.Range(func(key, count any) bool {
+			keyStr := key.(string)
+			parts := strings.Split(keyStr, "|")
+			user, ip := parts[0], parts[1]
+			userStr, tenantStr := extractUserAndTenant(user)
+
+			if atomicPtr, ok := count.(*atomic.Uint64); ok {
+				requestCount := atomicPtr.Load()
+				requestsByIPGauge.With(prometheus.Labels{
+					"pod":    cfg.PodName,
+					"user":   userStr,
+					"tenant": tenantStr,
+					"ip":     ip,
+				}).Set(float64(requestCount))
+			}
+			return true
+		})
+	}
+
+	if metricsConfig.TrackBytesSentByIP {
+		// Publish bytes sent per IP & User
+		metrics.BytesSentByIP.Range(func(key, bytesSent any) bool {
+			keyStr := key.(string)
+			parts := strings.Split(keyStr, "|")
+			user, ip := parts[0], parts[1]
+			userStr, tenantStr := extractUserAndTenant(user)
+
+			if atomicPtr, ok := bytesSent.(*atomic.Uint64); ok {
+				totalBytesSent := atomicPtr.Load()
+				bytesSentByIPGauge.With(prometheus.Labels{
+					"pod":    cfg.PodName,
+					"user":   userStr,
+					"tenant": tenantStr,
+					"ip":     ip,
+				}).Set(float64(totalBytesSent))
+			}
+			return true
+		})
+	}
+
+	if metricsConfig.TrackBytesReceivedByIP {
+		// Publish bytes received per IP & User
+		metrics.BytesReceivedByIP.Range(func(key, bytesReceived any) bool {
+			keyStr := key.(string)
+			parts := strings.Split(keyStr, "|")
+			user, ip := parts[0], parts[1]
+			userStr, tenantStr := extractUserAndTenant(user)
+
+			if atomicPtr, ok := bytesReceived.(*atomic.Uint64); ok {
+				totalBytesReceived := atomicPtr.Load()
+				bytesReceivedByIPGauge.With(prometheus.Labels{
+					"pod":    cfg.PodName,
+					"user":   userStr,
+					"tenant": tenantStr,
+					"ip":     ip,
+				}).Set(float64(totalBytesReceived))
+			}
+			return true
+		})
+	}
+
+	if metricsConfig.TrackErrorsByUser {
+		// Publish HTTP errors per User & Bucket
+		metrics.ErrorsByUserAndBucket.Range(func(key, count any) bool {
+			keyStr := key.(string)
+			parts := strings.Split(keyStr, "|")
+			user, bucket, status := parts[0], parts[1], parts[2]
+			userStr, tenantStr := extractUserAndTenant(user)
+
+			// Exclude HTTP status codes in the 2xx range
+			if strings.HasPrefix(status, "2") {
+				return true
+			}
+
+			if atomicPtr, ok := count.(*atomic.Uint64); ok {
+				errorCount := atomicPtr.Load()
+				httpErrorsByUserCounter.With(prometheus.Labels{
+					"pod":         cfg.PodName,
+					"user":        userStr,
+					"tenant":      tenantStr,
+					"bucket":      bucket,
+					"http_status": status,
+				}).Add(float64(errorCount))
+			}
+			return true
+		})
+	}
+
+	if metricsConfig.TrackErrorsByBucket {
+		metrics.ErrorsByUserAndBucket.Range(func(key, count any) bool {
+			parts := strings.Split(key.(string), "|")
+			if len(parts) != 3 {
+				log.Warn().Msgf("Invalid key format in ErrorsByUserAndBucket: %v", key)
+				return true
+			}
+			_, bucket, status := parts[0], parts[1], parts[2]
+			errorCount := float64(count.(*atomic.Uint64).Load())
+
+			errorsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        "all",
+				"tenant":      "all",
+				"bucket":      bucket,
 				"http_status": status,
-			}).Add(float64(errorCount))
+			}).Add(errorCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackErrorsByStatus {
+		metrics.RequestsByStatusCode.Range(func(status, count any) bool {
+			requestCount := float64(count.(*atomic.Uint64).Load())
+
+			errorsCounter.With(prometheus.Labels{
+				"pod":         cfg.PodName,
+				"user":        "all",
+				"tenant":      "all",
+				"bucket":      "all",
+				"http_status": status.(string),
+			}).Add(requestCount)
+
+			return true
+		})
+	}
+
+	if metricsConfig.TrackErrorsByIP {
+		// Publish HTTP errors per IP & Bucket
+		metrics.ErrorsByIPAndBucket.Range(func(key, count any) bool {
+			keyStr := key.(string)
+			parts := strings.Split(keyStr, "|")
+			ip, bucket, status := parts[0], parts[1], parts[2]
+
+			// Exclude HTTP status codes in the 2xx range
+			if strings.HasPrefix(status, "2") {
+				return true
+			}
+
+			if atomicPtr, ok := count.(*atomic.Uint64); ok {
+				errorCount := atomicPtr.Load()
+				httpErrorsByIPCounter.With(prometheus.Labels{
+					"pod":         cfg.PodName,
+					"ip":          ip,
+					"bucket":      bucket,
+					"http_status": status,
+				}).Add(float64(errorCount))
+			}
+			return true
+		})
+	}
+
+	// Update request duration histogram (latency metrics)
+	metrics.LatencyByMethod.Range(func(key, totalLatency any) bool {
+		parts := strings.Split(key.(string), "|")
+		if len(parts) != 3 {
+			log.Warn().Msgf("Invalid key format in LatencyByMethod: %v", key)
+			return true
 		}
-		return true
-	})
+		user, bucket, method := parts[0], parts[1], parts[2]
+		userStr, tenantStr := extractUserAndTenant(user)
 
-	// Publish HTTP errors per IP & Bucket
-	metrics.ErrorsByIPAndBucket.Range(func(key, count interface{}) bool {
-		keyStr := key.(string)
-		parts := strings.Split(keyStr, "|")
-		ip, bucket, status := parts[0], parts[1], parts[2]
-
-		// Exclude HTTP status codes in the 2xx range
-		if strings.HasPrefix(status, "2") {
+		// Fetch request count for this method
+		countVal, exists := metrics.RequestsByMethod.Load(key)
+		if !exists {
+			return true // Skip if no requests exist for this method
+		}
+		count := float64(countVal.(*atomic.Uint64).Load())
+		if count == 0 {
 			return true
 		}
 
-		if atomicPtr, ok := count.(*atomic.Uint64); ok {
-			errorCount := atomicPtr.Load()
-			httpErrorsByIPCounter.With(prometheus.Labels{
-				"pod":         cfg.PodName,
-				"ip":          ip,
-				"bucket":      bucket,
-				"http_status": status,
-			}).Add(float64(errorCount))
+		// Compute avg latency (convert ms → sec)
+		avgLatencySec := float64(totalLatency.(*atomic.Uint64).Load()) / count / 1000.0
+
+		if metricsConfig.TrackLatencyByBucketAndMethod {
+			// Fine-grained latency tracking per bucket & method
+			requestsDurationHistogram.With(prometheus.Labels{
+				// "pod":    cfg.PodName,
+				"user":   userStr,
+				"tenant": tenantStr,
+				"bucket": bucket,
+				"method": method,
+			}).Observe(avgLatencySec)
 		}
+
+		if metricsConfig.TrackLatencyByMethod {
+			// Aggregated latency for all users (reduces cardinality)
+			requestsDurationHistogram.With(prometheus.Labels{
+				// "pod":    cfg.PodName,
+				"user":   "all",
+				"tenant": "all",
+				"bucket": bucket,
+				"method": method,
+			}).Observe(avgLatencySec)
+		}
+
+		if metricsConfig.TrackLatencyByBucket {
+			requestsDurationHistogram.With(prometheus.Labels{
+				"user":   "all",
+				"tenant": "all",
+				"bucket": bucket,
+				"method": "all",
+			}).Observe(avgLatencySec)
+		}
+
+		if metricsConfig.TrackLatencyByTenant {
+			requestsDurationHistogram.With(prometheus.Labels{
+				"user":   "all",
+				"tenant": tenantStr,
+				"bucket": "all",
+				"method": "all",
+			}).Observe(avgLatencySec)
+		}
+
+		if metricsConfig.TrackLatencyByUser {
+			requestsDurationHistogram.With(prometheus.Labels{
+				"user":   userStr,
+				"tenant": tenantStr,
+				"bucket": "all",
+				"method": "all",
+			}).Observe(avgLatencySec)
+		}
+
+		// // Aggregate latency for all methods
+		// requestsDurationHistogram.With(prometheus.Labels{
+		// 	"pod":    cfg.PodName,
+		// 	"user":   userStr,
+		// 	"tenant": tenantStr,
+		// 	"bucket": bucket,
+		// 	"method": "all",
+		// }).Observe(avgLatencySec)
+
 		return true
 	})
 
 	log.Info().Msg("Updated Prometheus metrics for users and buckets")
 }
 
-func StartPrometheusServer(port int) {
+func StartPrometheusServer(port int, metricsConfig *MetricsConfig) {
+	// Initialize Prometheus settings based on the configuration
+	initPrometheusSettings(metricsConfig)
+
+	// Start the Prometheus HTTP server
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
 		log.Info().Msgf("starting prometheus metrics server on :%d", port)


### PR DESCRIPTION
- ops-log producer metrics configuration support
- ops-log producer truncate-log-on-start support
- mutating webhook for ops-log configuration support
- mutating webhook rgw annotation for adding prysm-sidecar (prysm-sidecar: yes)
- mutating webhook prysm-sidecar/sidecar-env-secret config secret name support