### PR TITLE
Add Renovate configuration for automated dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "default:pinDigestsDisabled",
+    "mergeConfidence:all-badges",
+    "docker:disable"
+  ],
+  "commitMessageAction": "Renovate: Update",
+  "constraints": {
+    "go": "1.26"
+  },
+  "dependencyDashboardOSVVulnerabilitySummary": "all",
+  "osvVulnerabilityAlerts": true,
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "/.*/"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "External dependencies"
+    },
+    {
+      "matchPackageNames": [
+        "/^github\\.com\\/sapcc\\/.*/"
+      ],
+      "automerge": true,
+      "groupName": "github.com/sapcc"
+    },
+    {
+      "matchPackageNames": [
+        "/^github\\.com\\/cobaltcore-dev\\/.*/"
+      ],
+      "automerge": true,
+      "groupName": "github.com/cobaltcore-dev"
+    },
+    {
+      "matchPackageNames": [
+        "go",
+        "golang",
+        "actions/go-versions"
+      ],
+      "groupName": "golang",
+      "separateMinorPatch": true
+    },
+    {
+      "matchPackageNames": [
+        "go",
+        "golang",
+        "actions/go-versions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ],
+  "prHourlyLimit": 0,
+  "schedule": [
+    "before 8am on Friday"
+  ],
+  "semanticCommits": "disabled"
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,6 @@
       "matchPackageNames": [
         "/^github\\.com\\/sapcc\\/.*/"
       ],
-      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "groupName": "github.com/sapcc"
     },
@@ -39,7 +38,6 @@
       "matchPackageNames": [
         "/^github\\.com\\/cobaltcore-dev\\/.*/"
       ],
-      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "groupName": "github.com/cobaltcore-dev"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,7 @@
       "matchPackageNames": [
         "/^github\\.com\\/sapcc\\/.*/"
       ],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "groupName": "github.com/sapcc"
     },
@@ -38,6 +39,7 @@
       "matchPackageNames": [
         "/^github\\.com\\/cobaltcore-dev\\/.*/"
       ],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "groupName": "github.com/cobaltcore-dev"
     },


### PR DESCRIPTION
## Summary
- Adds Renovate bot configuration matching the pattern used in `liquid-ceph`
- Groups minor/patch external dependency updates into a single PR
- Automerges `github.com/sapcc` and `github.com/cobaltcore-dev` dependencies
- Gates Go minor/major version bumps behind dependency dashboard approval
- Runs `go mod tidy` and updates import paths after dependency bumps
- Enables OSV vulnerability alerts
- Schedules PRs for Friday mornings (before 8am)

## Test Plan
- [ ] Renovate bot picks up the config after merge
- [ ] Dependency Dashboard issue is created in the repo
- [ ] First grouped dependency PR appears on the next Friday

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency update management with grouped minor/patch updates, selective automerge for specified providers, and special handling for Go/tooling updates.
  * Enabled OSV vulnerability alerts with full summaries and post-update tidy/import fixes.
  * Set scheduled update window (early Friday), unlimited hourly PR allowance, and disabled semantic commits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cobaltcore-dev/prysm/pull/49)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->