### PR TITLE
fix(opslog): correct typo in --track-bucket-slo Prometheus precondition

### DIFF
--- a/pkg/commands/producer_ops_log.go
+++ b/pkg/commands/producer_ops_log.go
@@ -674,7 +674,7 @@ func init() {
 
 	existingOpsLogPreRunE := opsLogCmd.PreRunE
 	opsLogCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if opsTrackBucketSLO && !opsPrometheus {
+		if opsTrackBucketSLO && !opsPromEnabled {
 			return fmt.Errorf("--track-bucket-slo requires --prometheus")
 		}
 		if existingOpsLogPreRunE != nil {


### PR DESCRIPTION
On-behalf-of: SAP <filipp.akinfiev@clyso.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed validation for the `--track-bucket-slo` flag to correctly verify Prometheus availability before enabling bucket SLO tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cobaltcore-dev/prysm/pull/51)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->