### PR TITLE
chore: add Dependabot config and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and prysm contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Code owners for the prysm repository.
+#
+# These owners will be the default owners for everything in the repo and will
+# be automatically requested for review when someone opens a pull request.
+# A review from any one of the listed owners is sufficient to satisfy the
+# code-owner review requirement (configured via branch protection /
+# repository ruleset: "Require review from Code Owners" with required
+# approving review count = 1).
+#
+# Order is irrelevant; the last matching pattern takes precedence.
+
+* @senolcolak @sumitarora2786

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and prysm contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+updates:
+  # Go modules - main module
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - go
+
+  # Go modules - ops-log-k8s-mutating-wh submodule
+  - package-ecosystem: gomod
+    directory: "/ops-log-k8s-mutating-wh"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - go
+
+  # Dockerfile (root)
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+
+  # Dockerfile (webhook)
+  - package-ecosystem: docker
+    directory: "/ops-log-k8s-mutating-wh"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
## Summary

Adds two repo-protection / governance files:

### `.github/dependabot.yml`
Enables weekly automated dependency updates for:
- Go modules — root module and `ops-log-k8s-mutating-wh` submodule
- Docker base images — root `Dockerfile` and `ops-log-k8s-mutating-wh/Dockerfile`
- GitHub Actions used in workflows

This will surface PRs for vulnerable / outdated dependencies. Note: the repo currently has **13 open Dependabot security alerts** (6 high, 7 moderate, mostly in `nats-server/v2`); enabling Dependabot security updates in repo settings is recommended as a follow-up so security PRs are auto-opened.

### `.github/CODEOWNERS`
Assigns @senolcolak (Senol Colak) and @sumitarora2786 (Sumit Arora) as default owners for the entire repository.

GitHub CODEOWNERS semantics: when multiple owners are listed on the same line, **a review from any one of them satisfies the code-owner requirement**. To enforce this on `main`, the branch protection / ruleset must additionally have:
- `Require a pull request before merging` ✓
- `Require approvals` = **1**
- `Require review from Code Owners` ✓

These ruleset changes are not in this PR — they are configured in repo/org settings, not in code. Currently `main` has no such protection (only deletion + non-fast-forward are blocked by the org ruleset). Recommend adding the protection in a follow-up.

## Verification
- YAML structure follows the [official Dependabot schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).
- Both Dockerfiles referenced exist (`Dockerfile`, `ops-log-k8s-mutating-wh/Dockerfile`).
- Both GitHub handles resolved against the `cobaltcore-dev` org and commit history.
- DCO sign-off included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for code ownership assignments and automated dependency management across multiple package ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->