### PR TITLE
Feat/ops log audit env config

### DIFF
--- a/ops-log-k8s-mutating-wh/README.md
+++ b/ops-log-k8s-mutating-wh/README.md
@@ -165,6 +165,101 @@ in a ConfigMap.
 - Keeps configuration clean and modular
 - Avoids hardcoding environment variables into the webhook
 
+### Audit Trail (RabbitMQ)
+
+The sidecar can publish CADF audit events to RabbitMQ. All audit settings are
+configurable via environment variables, so they can be supplied through the
+Secret above without changing the webhook or the sidecar command line. Because
+the connection URL contains credentials, store these in a **Secret** (not a
+ConfigMap).
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prysm-sidecar-env
+  namespace: rook-ceph
+type: Opaque
+stringData:
+  AUDIT_ENABLED: "true"
+  AUDIT_RABBITMQ_URL: "amqp://user:password@rabbitmq.example:5672/"
+  AUDIT_QUEUE_NAME: "keystone.notifications.info"   # optional, this is the default
+  AUDIT_QUEUE_SIZE: "20"                            # optional, internal buffer size
+  AUDIT_DEBUG: "false"                              # optional, log published events
+```
+
+| Variable                  | Description                                          | Default                          |
+|---------------------------|------------------------------------------------------|----------------------------------|
+| `AUDIT_ENABLED`           | Publish CADF audit events to RabbitMQ               | `false`                          |
+| `AUDIT_RABBITMQ_URL`      | AMQP connection URL (`amqp://host:port/`)           | _empty_                          |
+| `AUDIT_RABBITMQ_USERNAME` | Username; overrides any userinfo in the URL          | _empty_                          |
+| `AUDIT_RABBITMQ_PASSWORD` | Password; overrides any userinfo in the URL          | _empty_                          |
+| `AUDIT_QUEUE_NAME`        | Target queue                                         | `keystone.notifications.info`    |
+| `AUDIT_QUEUE_SIZE`        | Internal event buffer size                           | `20`                             |
+| `AUDIT_DEBUG`             | Log every published event (verbose)                  | `false`                          |
+
+> If `AUDIT_ENABLED=true` but `AUDIT_RABBITMQ_URL` is empty, the sidecar logs a
+> warning and falls back to a no-op auditor — log processing is never blocked.
+
+#### Separate username / password (e.g. from Vault)
+
+The username and password can be supplied independently of the URL via
+`AUDIT_RABBITMQ_USERNAME` / `AUDIT_RABBITMQ_PASSWORD`. When set, they are
+composed into the URL's userinfo at runtime and **override** any credentials
+embedded in `AUDIT_RABBITMQ_URL`. This lets the two values come from two
+separate sources (such as two Vault entries) without string-building a
+connection URL:
+
+```yaml
+stringData:
+  AUDIT_ENABLED: "true"
+  AUDIT_RABBITMQ_URL: "amqp://rabbitmq.example:5672/"   # no credentials in the URL
+  AUDIT_RABBITMQ_USERNAME: "audit"
+  AUDIT_RABBITMQ_PASSWORD: "s3cr3t"
+```
+
+##### Sourcing the credentials from HashiCorp Vault
+
+The sidecar itself does **not** talk to Vault — keep it Vault-unaware. Instead,
+use an operator such as the
+[External Secrets Operator](https://external-secrets.io/) (or the HashiCorp
+Vault Secrets Operator) to project your two Vault entries into the Secret that
+the webhook injects. Example `ExternalSecret`:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prysm-sidecar-env
+  namespace: rook-ceph
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: prysm-sidecar-env   # the Secret referenced by the sidecar-env-secret annotation
+    template:
+      type: Opaque
+      data:
+        AUDIT_ENABLED: "true"
+        AUDIT_RABBITMQ_URL: "amqp://rabbitmq.example:5672/"
+        AUDIT_RABBITMQ_USERNAME: "{{ .username }}"
+        AUDIT_RABBITMQ_PASSWORD: "{{ .password }}"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: secret/data/rabbitmq/audit
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: secret/data/rabbitmq/audit
+        property: password
+```
+
+The operator renders a native `Secret`; the webhook injects it via `envFrom`
+exactly as above. Credentials never land in the Deployment spec or the webhook.
+
 ---
 ### Important Notes
 > The referenced Secret or ConfigMap must exist before the deployment is

--- a/pkg/commands/producer_ops_log.go
+++ b/pkg/commands/producer_ops_log.go
@@ -33,6 +33,8 @@ var (
 	// Audit flags
 	opsAuditEnabled           bool
 	opsAuditRabbitMQURL       string
+	opsAuditRabbitMQUsername  string
+	opsAuditRabbitMQPassword  string
 	opsAuditQueueName         string
 	opsAuditInternalQueueSize int
 	opsAuditDebug             bool
@@ -224,6 +226,8 @@ Following this configuration change, the RadosGW will log operations to the file
 			AuditSink: opslog.AuditSinkConfig{
 				Enabled:           opsAuditEnabled,
 				RabbitMQURL:       opsAuditRabbitMQURL,
+				RabbitMQUsername:  opsAuditRabbitMQUsername,
+				RabbitMQPassword:  opsAuditRabbitMQPassword,
 				QueueName:         opsAuditQueueName,
 				InternalQueueSize: opsAuditInternalQueueSize,
 				Debug:             opsAuditDebug,
@@ -642,6 +646,17 @@ func mergeOpsLogConfigWithEnv(cfg opslog.OpsLogConfig) opslog.OpsLogConfig {
 	cfg.MetricsConfig.TrackLatencyPerMethod = getEnvBool("TRACK_LATENCY_PER_METHOD", cfg.MetricsConfig.TrackLatencyPerMethod)
 	cfg.MetricsConfig.TrackLatencyPerBucketAndMethod = getEnvBool("TRACK_LATENCY_PER_BUCKET_AND_METHOD", cfg.MetricsConfig.TrackLatencyPerBucketAndMethod)
 
+	// Audit sink (RabbitMQ) configuration. These mirror the --audit-* flags so
+	// the sink can be enabled via env vars injected by the mutating webhook
+	// (Secret/ConfigMap) without editing the sidecar command line.
+	cfg.AuditSink.Enabled = getEnvBool("AUDIT_ENABLED", cfg.AuditSink.Enabled)
+	cfg.AuditSink.RabbitMQURL = getEnv("AUDIT_RABBITMQ_URL", cfg.AuditSink.RabbitMQURL)
+	cfg.AuditSink.RabbitMQUsername = getEnv("AUDIT_RABBITMQ_USERNAME", cfg.AuditSink.RabbitMQUsername)
+	cfg.AuditSink.RabbitMQPassword = getEnv("AUDIT_RABBITMQ_PASSWORD", cfg.AuditSink.RabbitMQPassword)
+	cfg.AuditSink.QueueName = getEnv("AUDIT_QUEUE_NAME", cfg.AuditSink.QueueName)
+	cfg.AuditSink.InternalQueueSize = getEnvInt("AUDIT_QUEUE_SIZE", cfg.AuditSink.InternalQueueSize)
+	cfg.AuditSink.Debug = getEnvBool("AUDIT_DEBUG", cfg.AuditSink.Debug)
+
 	return cfg
 }
 
@@ -663,7 +678,9 @@ func init() {
 
 	// Audit flags
 	opsLogCmd.Flags().BoolVar(&opsAuditEnabled, "audit-enabled", false, "Enable audit event publishing to RabbitMQ")
-	opsLogCmd.Flags().StringVar(&opsAuditRabbitMQURL, "audit-rabbitmq-url", "", "RabbitMQ connection URL (amqp://user:pass@host:port)")
+	opsLogCmd.Flags().StringVar(&opsAuditRabbitMQURL, "audit-rabbitmq-url", "", "RabbitMQ connection URL (amqp://host:port); credentials may be embedded or supplied via --audit-rabbitmq-username/--audit-rabbitmq-password")
+	opsLogCmd.Flags().StringVar(&opsAuditRabbitMQUsername, "audit-rabbitmq-username", "", "RabbitMQ username; overrides any userinfo in --audit-rabbitmq-url (e.g. sourced from a Vault entry)")
+	opsLogCmd.Flags().StringVar(&opsAuditRabbitMQPassword, "audit-rabbitmq-password", "", "RabbitMQ password; overrides any userinfo in --audit-rabbitmq-url (e.g. sourced from a Vault entry)")
 	opsLogCmd.Flags().StringVar(&opsAuditQueueName, "audit-queue-name", "keystone.notifications.info", "RabbitMQ queue name for audit events")
 	opsLogCmd.Flags().IntVar(&opsAuditInternalQueueSize, "audit-queue-size", 20, "Internal queue size for audit events")
 	opsLogCmd.Flags().BoolVar(&opsAuditDebug, "audit-debug", false, "Log published audit events for debugging")

--- a/pkg/commands/producer_ops_log.go
+++ b/pkg/commands/producer_ops_log.go
@@ -674,7 +674,7 @@ func init() {
 
 	existingOpsLogPreRunE := opsLogCmd.PreRunE
 	opsLogCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if opsTrackBucketSLO && !opsPrometheus {
+		if opsTrackBucketSLO && !opsPromEnabled {
 			return fmt.Errorf("--track-bucket-slo requires --prometheus")
 		}
 		if existingOpsLogPreRunE != nil {

--- a/pkg/commands/producer_ops_log_test.go
+++ b/pkg/commands/producer_ops_log_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and prysm contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/cobaltcore-dev/prysm/pkg/producers/opslog"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMergeOpsLogConfigWithEnv_AuditSink verifies that the audit/RabbitMQ sink
+// can be configured via environment variables (e.g. injected by the mutating
+// webhook through a Secret/ConfigMap), not just via command-line flags.
+func TestMergeOpsLogConfigWithEnv_AuditSink(t *testing.T) {
+	// Base config simulates the flag-derived defaults.
+	base := opslog.OpsLogConfig{
+		AuditSink: opslog.AuditSinkConfig{
+			Enabled:           false,
+			RabbitMQURL:       "",
+			QueueName:         "keystone.notifications.info",
+			InternalQueueSize: 20,
+			Debug:             false,
+		},
+	}
+
+	t.Run("env vars override flag defaults", func(t *testing.T) {
+		t.Setenv("AUDIT_ENABLED", "true")
+		t.Setenv("AUDIT_RABBITMQ_URL", "amqp://rabbit:5672/")
+		t.Setenv("AUDIT_RABBITMQ_USERNAME", "audit")
+		t.Setenv("AUDIT_RABBITMQ_PASSWORD", "s3cr3t")
+		t.Setenv("AUDIT_QUEUE_NAME", "custom.audit.queue")
+		t.Setenv("AUDIT_QUEUE_SIZE", "100")
+		t.Setenv("AUDIT_DEBUG", "true")
+
+		cfg := mergeOpsLogConfigWithEnv(base)
+
+		assert.True(t, cfg.AuditSink.Enabled)
+		assert.Equal(t, "amqp://rabbit:5672/", cfg.AuditSink.RabbitMQURL)
+		assert.Equal(t, "audit", cfg.AuditSink.RabbitMQUsername)
+		assert.Equal(t, "s3cr3t", cfg.AuditSink.RabbitMQPassword)
+		assert.Equal(t, "custom.audit.queue", cfg.AuditSink.QueueName)
+		assert.Equal(t, 100, cfg.AuditSink.InternalQueueSize)
+		assert.True(t, cfg.AuditSink.Debug)
+	})
+
+	t.Run("unset env vars preserve flag defaults", func(t *testing.T) {
+		cfg := mergeOpsLogConfigWithEnv(base)
+
+		assert.False(t, cfg.AuditSink.Enabled)
+		assert.Equal(t, "", cfg.AuditSink.RabbitMQURL)
+		assert.Equal(t, "", cfg.AuditSink.RabbitMQUsername)
+		assert.Equal(t, "", cfg.AuditSink.RabbitMQPassword)
+		assert.Equal(t, "keystone.notifications.info", cfg.AuditSink.QueueName)
+		assert.Equal(t, 20, cfg.AuditSink.InternalQueueSize)
+		assert.False(t, cfg.AuditSink.Debug)
+	})
+}

--- a/pkg/producers/opslog/audit.go
+++ b/pkg/producers/opslog/audit.go
@@ -6,6 +6,7 @@ package opslog
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -31,13 +32,19 @@ func InitAuditor(ctx context.Context, cfg AuditSinkConfig, registry prometheus.R
 		return audittools.NewNullAuditor()
 	}
 
+	connectionURL, err := buildRabbitMQConnectionURL(cfg.RabbitMQURL, cfg.RabbitMQUsername, cfg.RabbitMQPassword)
+	if err != nil {
+		log.Error().Err(err).Msg("Invalid RabbitMQ connection URL, falling back to NullAuditor")
+		return audittools.NewNullAuditor()
+	}
+
 	queueSize := cfg.InternalQueueSize
 	if queueSize == 0 {
 		queueSize = 20 // Default from audittools
 	}
 
 	auditor, err := audittools.NewAuditor(ctx, audittools.AuditorOpts{
-		ConnectionURL: cfg.RabbitMQURL,
+		ConnectionURL: connectionURL,
 		QueueName:     cfg.QueueName,
 		Observer: audittools.Observer{
 			TypeURI: "service/storage/object",
@@ -59,6 +66,31 @@ func InitAuditor(ctx context.Context, cfg AuditSinkConfig, registry prometheus.R
 		Msg("Audit trail initialized successfully")
 
 	return auditor
+}
+
+// buildRabbitMQConnectionURL injects an explicit username/password into the
+// userinfo of an AMQP connection URL. Explicit credentials override any
+// already present in the URL. When both username and password are empty, the
+// URL is returned unchanged. This allows the credentials to be supplied as two
+// independent values (e.g. two Vault entries synced into a Secret) rather than
+// embedded in a single connection string.
+func buildRabbitMQConnectionURL(rawURL, username, password string) (string, error) {
+	if username == "" && password == "" {
+		return rawURL, nil
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid RabbitMQ URL: %w", err)
+	}
+
+	if password != "" {
+		u.User = url.UserPassword(username, password)
+	} else {
+		u.User = url.User(username)
+	}
+
+	return u.String(), nil
 }
 
 // ToAuditEvent converts an S3OperationLog to an audittools.Event.

--- a/pkg/producers/opslog/audit.go
+++ b/pkg/producers/opslog/audit.go
@@ -79,6 +79,10 @@ func buildRabbitMQConnectionURL(rawURL, username, password string) (string, erro
 		return rawURL, nil
 	}
 
+	if username == "" && password != "" {
+		return "", fmt.Errorf("invalid RabbitMQ credentials: password provided without username")
+	}
+
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid RabbitMQ URL: %w", err)

--- a/pkg/producers/opslog/audit_test.go
+++ b/pkg/producers/opslog/audit_test.go
@@ -68,4 +68,9 @@ func TestBuildRabbitMQConnectionURL(t *testing.T) {
 		_, err := buildRabbitMQConnectionURL("://not a url", "u", "p")
 		require.Error(t, err)
 	})
+
+	t.Run("password without username is rejected", func(t *testing.T) {
+		_, err := buildRabbitMQConnectionURL("amqp://rabbitmq.example:5672/", "", "s3cr3t")
+		require.Error(t, err)
+	})
 }

--- a/pkg/producers/opslog/audit_test.go
+++ b/pkg/producers/opslog/audit_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and prysm contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package opslog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildRabbitMQConnectionURL verifies that explicitly supplied username and
+// password (e.g. sourced from two separate Vault entries synced into a Secret)
+// are composed into the AMQP connection URL's userinfo.
+func TestBuildRabbitMQConnectionURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		username string
+		password string
+		want     string
+	}{
+		{
+			name:   "no credentials returns url unchanged",
+			rawURL: "amqp://rabbitmq.example:5672/",
+			want:   "amqp://rabbitmq.example:5672/",
+		},
+		{
+			name:     "username and password injected into bare host url",
+			rawURL:   "amqp://rabbitmq.example:5672/",
+			username: "audit",
+			password: "s3cr3t",
+			want:     "amqp://audit:s3cr3t@rabbitmq.example:5672/",
+		},
+		{
+			name:     "username only",
+			rawURL:   "amqp://rabbitmq.example:5672/",
+			username: "audit",
+			want:     "amqp://audit@rabbitmq.example:5672/",
+		},
+		{
+			name:     "explicit credentials override userinfo already in url",
+			rawURL:   "amqp://old:oldpass@rabbitmq.example:5672/",
+			username: "audit",
+			password: "s3cr3t",
+			want:     "amqp://audit:s3cr3t@rabbitmq.example:5672/",
+		},
+		{
+			name:     "special characters in password are percent-encoded",
+			rawURL:   "amqp://rabbitmq.example:5672/vhost",
+			username: "audit",
+			password: "p@ss/w:rd",
+			want:     "amqp://audit:p%40ss%2Fw%3Ard@rabbitmq.example:5672/vhost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildRabbitMQConnectionURL(tt.rawURL, tt.username, tt.password)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("invalid url with credentials returns error", func(t *testing.T) {
+		_, err := buildRabbitMQConnectionURL("://not a url", "u", "p")
+		require.Error(t, err)
+	})
+}

--- a/pkg/producers/opslog/config.go
+++ b/pkg/producers/opslog/config.go
@@ -6,8 +6,15 @@ package opslog
 
 // AuditSinkConfig defines the RabbitMQ audit sink configuration.
 type AuditSinkConfig struct {
-	Enabled           bool   `mapstructure:"enabled"`
-	RabbitMQURL       string `mapstructure:"rabbitmq_url"`
+	Enabled     bool   `mapstructure:"enabled"`
+	RabbitMQURL string `mapstructure:"rabbitmq_url"`
+	// RabbitMQUsername and RabbitMQPassword, when set, are composed into the
+	// RabbitMQURL userinfo at runtime, overriding any credentials embedded in
+	// the URL. This lets the username and password be supplied as two separate
+	// values (e.g. two Vault entries synced into a Secret) instead of being
+	// baked into a single connection string.
+	RabbitMQUsername  string `mapstructure:"rabbitmq_username"`
+	RabbitMQPassword  string `mapstructure:"rabbitmq_password"`
 	QueueName         string `mapstructure:"queue_name"`
 	InternalQueueSize int    `mapstructure:"internal_queue_size"` // Optional, defaults to 20
 	Debug             bool   `mapstructure:"debug"`               // Log published events


### PR DESCRIPTION
- extended auth config for log audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RabbitMQ audit trail support with separate credential configuration fields.
  * Introduced CLI flags `--audit-rabbitmq-username` and `--audit-rabbitmq-password` to configure credentials independently of the connection URL.
* **Bug Fixes**
  * Improved RabbitMQ connection handling by safely composing credentials into the URL (including proper encoding) and validating credential requirements.
* **Tests**
  * Added coverage for audit/RabbitMQ URL construction and environment-driven config overrides.
* **Documentation**
  * Updated the “Audit Trail (RabbitMQ)” section with examples, environment variable behavior, and credential sourcing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->