### PR TITLE
stream-decode ops log to handle concatenated RGW entries and stop the…

### DIFF
--- a/pkg/producers/opslog/opslog.go
+++ b/pkg/producers/opslog/opslog.go
@@ -6,14 +6,12 @@ package opslog
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	json "github.com/goccy/go-json"
@@ -258,46 +256,18 @@ func processLogEntries(cfg OpsLogConfig, nc *nats.Conn, watcher *fsnotify.Watche
 		return lastOffset, fmt.Errorf("failed to seek log file: %w", err)
 	}
 
-	// reader := bufio.NewReader(file)
 	reader := bufio.NewReaderSize(file, 64*1024)
-	var newOffset = lastOffset
 
-	logPool := sync.Pool{
-		New: func() any { return new(S3OperationLog) },
-	}
-
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return newOffset, fmt.Errorf("error reading log file: %w", err)
-		}
-
-		// Update offset
-		newOffset += int64(len(line))
-
-		str := strings.TrimSpace(string(line))
-		if len(str) < 2 || str[0] != '{' || str[len(str)-1] != '}' {
-			continue
-		}
-
-		logEntry := logPool.Get().(*S3OperationLog)
-		// Reset the pooled instance: json.Unmarshal only sets fields present in
-		// the input, so omitted fields (e.g. keystone_scope) would otherwise
-		// retain values from a previously processed entry.
-		*logEntry = S3OperationLog{}
-		if err := json.Unmarshal([]byte(line), logEntry); err != nil {
-			log.Warn().Err(err).Str("raw", str).Msg("Skipping invalid JSON entry")
-			logPool.Put(logEntry)
-			continue
-		}
-
+	// RGW writes the ops log as a stream of JSON objects that are not reliably
+	// newline-separated — consecutive entries are often concatenated as
+	// `{...}{...}`. decodeOpsLogEntries yields one complete object at a time and
+	// reports the byte offset just past the last COMPLETE object, so a partial
+	// tail write is neither lost nor double-counted.
+	consumed := decodeOpsLogEntries(reader, func(raw json.RawMessage, logEntry *S3OperationLog) {
 		// Ignore anonymous requests if configured
 		if cfg.IgnoreAnonymousRequests && logEntry.User == "anonymous" {
 			log.Trace().Str("user", logEntry.User).Msg("Skipping anonymous request")
-			continue
+			return
 		}
 
 		// Normalize bucket name before processing
@@ -357,22 +327,9 @@ func processLogEntries(cfg OpsLogConfig, nc *nats.Conn, watcher *fsnotify.Watche
 			}
 		}
 
-		logPool.Put(logEntry)
-
 		// Print to stdout if enabled
 		if cfg.LogToStdout {
-			if cfg.LogPrettyPrint {
-				var buf bytes.Buffer
-				if err := json.NewEncoder(&buf).Encode(json.RawMessage(str)); err == nil {
-					var pretty bytes.Buffer
-					if err := json.Indent(&pretty, buf.Bytes(), "", "  "); err == nil {
-						fmt.Println(pretty.String())
-					}
-				}
-			} else {
-				// Print the raw line
-				fmt.Println(str)
-			}
+			printOpsLogLine(raw, cfg.LogPrettyPrint)
 		}
 
 		// Publish raw log entry to NATS
@@ -381,7 +338,9 @@ func processLogEntries(cfg OpsLogConfig, nc *nats.Conn, watcher *fsnotify.Watche
 				log.Error().Err(err).Msg("Error publishing log entry to NATS")
 			}
 		}
-	}
+	})
+
+	newOffset := lastOffset + consumed
 
 	// Rotate log file if needed
 	rotateLogIfNeeded(cfg, watcher)

--- a/pkg/producers/opslog/opslog_parse.go
+++ b/pkg/producers/opslog/opslog_parse.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and prysm contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package opslog
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/rs/zerolog/log"
+)
+
+// decodeOpsLogEntries decodes consecutive JSON ops-log objects from r, invoking
+// handle(raw, entry) for each complete object in order. It returns the number of
+// bytes consumed up to the end of the last complete object.
+//
+// RGW writes the ops log as a stream of JSON objects that are NOT reliably
+// newline-separated — consecutive entries are frequently concatenated as
+// `{...}{...}` with no delimiter. A line-based reader (ReadString('\n') +
+// Unmarshal) mis-reads such a run as one malformed line, which both drops those
+// entries (silent metric/audit loss) and, historically, logged the entire raw
+// line per failure — a stdout firehose. json.Decoder instead yields one complete
+// value at a time regardless of the whitespace between them.
+//
+// The returned byte count is the offset just past the last COMPLETE object, so a
+// partial object still being written at the tail of the file is not consumed and
+// is re-read (not lost, not duplicated) on the next pass.
+func decodeOpsLogEntries(r io.Reader, handle func(raw json.RawMessage, entry *S3OperationLog)) int64 {
+	// base accumulates bytes consumed by decoders discarded during resync; the
+	// live decoder's InputOffset() is relative to base. lastGood is the absolute
+	// offset just past the last COMPLETE object — the safe point to resume from.
+	var base, lastGood int64
+	dec := json.NewDecoder(r)
+	var entry S3OperationLog
+
+	for {
+		var raw json.RawMessage
+		err := dec.Decode(&raw)
+		if err == nil {
+			lastGood = base + dec.InputOffset()
+			entry = S3OperationLog{}
+			if uerr := json.Unmarshal(raw, &entry); uerr != nil {
+				// Valid JSON but not our shape — skip this one entry (the decoder
+				// has already advanced past it) rather than dropping the stream.
+				opsLogParseErrLogger.warn(uerr, raw)
+				continue
+			}
+			handle(raw, &entry)
+			continue
+		}
+
+		// Clean end: only trailing whitespace remained. Return the last complete
+		// boundary (not the whitespace-inclusive InputOffset).
+		if err == io.EOF {
+			return lastGood
+		}
+
+		// Any other error means the bytes after lastGood don't (yet) form a
+		// complete value. Try to skip past the next newline, capturing a bounded
+		// sample of the offending bytes for diagnostics:
+		//   - newline ahead        → a torn record mid-stream; log (rate-limited,
+		//     length-capped, with sample) and resume so it can't wedge the stream.
+		//   - clean EOF, no newline → a partial object still being written at the
+		//     tail; wait silently, don't advance past the last complete object.
+		//   - genuine reader error  → surface it (never stall silently), then wait.
+		errOffset := dec.InputOffset()
+		mr := io.MultiReader(dec.Buffered(), r)
+		var sample capSampler
+		skipped, skipErr := skipPastNewline(io.TeeReader(mr, &sample))
+		if skipped < 0 {
+			if skipErr != nil && !errors.Is(skipErr, io.EOF) {
+				log.Warn().Err(skipErr).Msg("ops-log read error during resync; will retry")
+			}
+			return lastGood
+		}
+		opsLogParseErrLogger.warn(err, sample.bytes())
+		base += errOffset + skipped
+		lastGood = base
+		dec = json.NewDecoder(mr)
+	}
+}
+
+// skipPastNewline consumes bytes from r up to and including the next '\n'. It
+// returns the number of bytes consumed and nil on success, or -1 and the
+// terminating error otherwise — io.EOF for a clean partial tail, any other error
+// for a genuine reader failure the caller must not swallow.
+func skipPastNewline(r io.Reader) (int64, error) {
+	var n int64
+	buf := make([]byte, 1)
+	for {
+		m, err := r.Read(buf)
+		if m > 0 {
+			n++
+			if buf[0] == '\n' {
+				return n, nil
+			}
+		}
+		if err != nil {
+			return -1, err
+		}
+	}
+}
+
+// capSampler collects up to opsLogSampleCap bytes for a diagnostic sample and
+// discards the rest. It always reports a full write so io.TeeReader never errors,
+// keeping the skipped-region peek bounded regardless of how large that region is.
+type capSampler struct{ buf []byte }
+
+const opsLogSampleCap = 256
+
+func (s *capSampler) Write(p []byte) (int, error) {
+	if room := opsLogSampleCap - len(s.buf); room > 0 {
+		if room > len(p) {
+			room = len(p)
+		}
+		s.buf = append(s.buf, p[:room]...)
+	}
+	return len(p), nil
+}
+
+func (s *capSampler) bytes() []byte { return s.buf }
+
+// printOpsLogLine writes a single ops-log entry to stdout. Each object is
+// emitted on its own line (compact), or indented when pretty-printing is on.
+func printOpsLogLine(raw json.RawMessage, pretty bool) {
+	if pretty {
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, raw, "", "  "); err == nil {
+			fmt.Println(buf.String())
+			return
+		}
+	}
+	fmt.Println(string(raw))
+}
+
+// opsLogParseErrLogger is the shared rate limiter for ops-log parse warnings.
+// A malformed ops-log stream must never be able to reproduce the stdout log
+// storm, so parse errors are emitted at most once per interval with a suppressed
+// count and a length-capped sample.
+var opsLogParseErrLogger = &rateLimitedLogger{interval: 10 * time.Second}
+
+type rateLimitedLogger struct {
+	mu         sync.Mutex
+	interval   time.Duration
+	last       time.Time
+	suppressed int
+}
+
+func (l *rateLimitedLogger) warn(err error, raw []byte) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	if !l.last.IsZero() && now.Sub(l.last) < l.interval {
+		l.suppressed++
+		return
+	}
+
+	ev := log.Warn().Err(err)
+	if l.suppressed > 0 {
+		ev = ev.Int("suppressed", l.suppressed)
+	}
+	ev.Str("sample", sampleBytes(raw, 256)).Msg("Skipping malformed ops-log entry")
+
+	l.last = now
+	l.suppressed = 0
+}
+
+// sampleBytes returns at most maxLen bytes of b as a string, marking truncation.
+func sampleBytes(b []byte, maxLen int) string {
+	if len(b) > maxLen {
+		return string(b[:maxLen]) + "…(truncated)"
+	}
+	return string(b)
+}

--- a/pkg/producers/opslog/opslog_parse_test.go
+++ b/pkg/producers/opslog/opslog_parse_test.go
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and prysm contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package opslog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRateLimitedLogger_Suppression verifies the storm-prevention mechanism:
+// warnings within the interval are counted (suppressed) rather than emitted, and
+// the first warning after the interval elapses emits and resets the counter.
+func TestRateLimitedLogger_Suppression(t *testing.T) {
+	l := &rateLimitedLogger{interval: 40 * time.Millisecond}
+
+	// First call emits (last is zero) and leaves suppressed at 0.
+	l.warn(errors.New("boom"), []byte("sample"))
+	assert.Equal(t, 0, l.suppressed, "first warning emits, nothing suppressed")
+
+	// Rapid follow-ups within the interval are suppressed, not emitted.
+	l.warn(errors.New("boom"), nil)
+	l.warn(errors.New("boom"), nil)
+	assert.Equal(t, 2, l.suppressed, "warnings within the interval are counted")
+
+	// After the interval elapses, the next warning emits and resets the counter.
+	time.Sleep(80 * time.Millisecond)
+	l.warn(errors.New("boom"), nil)
+	assert.Equal(t, 0, l.suppressed, "warning after the interval emits and resets")
+}
+
+// collect runs decodeOpsLogEntries over input and returns the operations parsed
+// (in order) plus the number of bytes reported as consumed.
+func collect(input string) ([]string, int64) {
+	var ops []string
+	consumed := decodeOpsLogEntries(strings.NewReader(input), func(_ json.RawMessage, e *S3OperationLog) {
+		ops = append(ops, e.Operation)
+	})
+	return ops, consumed
+}
+
+func TestDecodeOpsLogEntries(t *testing.T) {
+	objA := `{"operation":"a"}`
+	objB := `{"operation":"b"}`
+	objC := `{"operation":"c"}`
+
+	tests := []struct {
+		name         string
+		input        string
+		wantOps      []string
+		wantConsumed int64
+	}{
+		{
+			name:         "single newline-terminated",
+			input:        objA + "\n",
+			wantOps:      []string{"a"},
+			wantConsumed: int64(len(objA)),
+		},
+		{
+			// The actual production bug: RGW concatenates entries with no
+			// separator. The old line parser dropped both and firehosed stdout.
+			name:         "concatenated without separator",
+			input:        objA + objB + objC,
+			wantOps:      []string{"a", "b", "c"},
+			wantConsumed: int64(len(objA + objB + objC)),
+		},
+		{
+			name:         "newline separated",
+			input:        objA + "\n" + objB + "\n",
+			wantOps:      []string{"a", "b"},
+			wantConsumed: int64(len(objA + "\n" + objB)),
+		},
+		{
+			name:         "whitespace between",
+			input:        " " + objA + "  \n " + objB + " ",
+			wantOps:      []string{"a", "b"},
+			wantConsumed: int64(len(" " + objA + "  \n " + objB)),
+		},
+		{
+			// Partial object mid-write at the tail must NOT be consumed, so it is
+			// re-read whole on the next pass (not lost, not duplicated).
+			name:         "partial trailing object",
+			input:        objA + objB + `{"operation":"c`,
+			wantOps:      []string{"a", "b"},
+			wantConsumed: int64(len(objA + objB)),
+		},
+		{
+			name:         "empty input",
+			input:        "",
+			wantOps:      nil,
+			wantConsumed: 0,
+		},
+		{
+			// A valid entry followed by garbage: the good entry is processed, the
+			// stream stops at the garbage (rate-limited log, no storm), and the
+			// offset stays at the last good boundary.
+			name:         "valid then garbage",
+			input:        objA + "garbage",
+			wantOps:      []string{"a"},
+			wantConsumed: int64(len(objA)),
+		},
+		{
+			name:         "leading garbage yields nothing",
+			input:        "garbage",
+			wantOps:      nil,
+			wantConsumed: 0,
+		},
+		{
+			// A torn record in the MIDDLE must not wedge the stream: skip past the
+			// next newline and recover the following entries (no permanent stall).
+			name:         "garbage between valid entries recovers",
+			input:        objA + "not-json\n" + objB,
+			wantOps:      []string{"a", "b"},
+			wantConsumed: int64(len(objA + "not-json\n" + objB)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops, consumed := collect(tt.input)
+			assert.Equal(t, tt.wantOps, ops, "parsed operations")
+			assert.Equal(t, tt.wantConsumed, consumed, "consumed offset")
+		})
+	}
+}
+
+// errReader yields data, then a genuine (non-EOF) read error — an unreadable
+// file surfaced through the decoder.
+type errReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.pos < len(r.data) {
+		n := copy(p, r.data[r.pos:])
+		r.pos += n
+		return n, nil
+	}
+	return 0, r.err
+}
+
+// TestDecodeOpsLogEntries_GenuineReaderError verifies that a genuine reader error
+// after a valid entry does not stall or panic: the good entry is processed and
+// the function returns the last complete boundary (the error is logged, not
+// silently swallowed — see the resync path).
+func TestDecodeOpsLogEntries_GenuineReaderError(t *testing.T) {
+	objA := `{"operation":"a"}`
+	r := &errReader{data: []byte(objA), err: errors.New("disk gone")}
+
+	var ops []string
+	consumed := decodeOpsLogEntries(r, func(_ json.RawMessage, e *S3OperationLog) {
+		ops = append(ops, e.Operation)
+	})
+	assert.Equal(t, []string{"a"}, ops, "entry before the error is processed")
+	assert.Equal(t, int64(len(objA)), consumed, "offset stays at the last complete object")
+}
+
+// TestCapSampler verifies the diagnostic sampler is bounded regardless of input
+// size, so a huge skipped region can never be buffered whole.
+func TestCapSampler(t *testing.T) {
+	var s capSampler
+	n, err := s.Write(make([]byte, 1000))
+	assert.NoError(t, err)
+	assert.Equal(t, 1000, n, "reports a full write so TeeReader never errors")
+	assert.Len(t, s.bytes(), opsLogSampleCap, "sample is capped")
+}
+
+// TestDecodeOpsLogEntries_ResumeAcrossReads simulates the real caller: a partial
+// tail on the first read is completed on the second, and the offset advances
+// correctly with no duplicate or lost entries.
+func TestDecodeOpsLogEntries_ResumeAcrossReads(t *testing.T) {
+	objA := `{"operation":"a"}`
+	objB := `{"operation":"b"}`
+
+	// First pass sees A plus a partial B.
+	full := objA + objB
+	firstChunk := objA + objB[:len(objB)-3] // B truncated mid-write
+
+	ops1, consumed1 := collect(firstChunk)
+	assert.Equal(t, []string{"a"}, ops1)
+	assert.Equal(t, int64(len(objA)), consumed1, "partial B not consumed")
+
+	// Second pass resumes from the reported offset and now sees the full B.
+	ops2, consumed2 := collect(full[consumed1:])
+	assert.Equal(t, []string{"b"}, ops2)
+	assert.Equal(t, int64(len(objB)), consumed2)
+}

--- a/pkg/producers/opslog/opslog_stream_integration_test.go
+++ b/pkg/producers/opslog/opslog_stream_integration_test.go
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and prysm contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package opslog
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// entryJSON builds a compact ops-log entry carrying a unique trans_id.
+func entryJSON(tid string) string {
+	return fmt.Sprintf(
+		`{"trans_id":%q,"operation":"get_obj","bucket":"b","user":"proj$proj","http_status":"200","total_time":1}`,
+		tid,
+	)
+}
+
+// drainCount reads the file the way the watcher loop does — open, reset offset on
+// truncation, seek, stream-decode, advance — until a full pass makes no progress.
+// It records every processed trans_id and counts any processed more than once.
+// It is goroutine-safe (no testing.T / FailNow) so it can run concurrently with
+// writers; I/O errors just yield no progress.
+func drainCount(path string, startOffset int64, seen *sync.Map, dupes *int64) int64 {
+	offset := startOffset
+	for {
+		next := readOnce(path, offset, seen, dupes)
+		if next == offset {
+			return offset
+		}
+		offset = next
+	}
+}
+
+func readOnce(path string, lastOffset int64, seen *sync.Map, dupes *int64) int64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return lastOffset
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return lastOffset
+	}
+	if lastOffset > fi.Size() { // truncation reset — mirrors processLogEntries
+		lastOffset = 0
+	}
+	if _, err := f.Seek(lastOffset, io.SeekStart); err != nil {
+		return lastOffset
+	}
+
+	consumed := decodeOpsLogEntries(f, func(_ json.RawMessage, e *S3OperationLog) {
+		if _, loaded := seen.LoadOrStore(e.TransID, struct{}{}); loaded {
+			atomic.AddInt64(dupes, 1)
+		}
+	})
+	return lastOffset + consumed
+}
+
+// TestStream_ConcurrentConcatenatedNoLoss reproduces the production conditions:
+// several writers appending ops-log entries, ~half with NO newline separator
+// (RGW concatenation) and some written in two chunks (partial tail windows).
+// After all writes, a full drain must have processed every entry exactly once.
+func TestStream_ConcurrentConcatenatedNoLoss(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ops.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	require.NoError(t, err)
+
+	const writers = 4
+	const perWriter = 750
+
+	var writeMu sync.Mutex // O_APPEND is atomic per write; this also serializes chunked writes
+	var written sync.Map
+	var writtenCount int64
+
+	// Reader runs concurrently with writers to exercise read-while-write.
+	var seen sync.Map
+	var dupes int64
+	stop := make(chan struct{})
+	var readerWG sync.WaitGroup
+	readerWG.Add(1)
+	go func() {
+		defer readerWG.Done()
+		var off int64
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				off = drainCount(path, off, &seen, &dupes)
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				tid := fmt.Sprintf("tx-%d-%d", id, i)
+				obj := entryJSON(tid)
+				sep := "\n"
+				if i%2 == 0 {
+					sep = "" // concatenation: no separator
+				}
+				writeMu.Lock()
+				if i%5 == 0 { // chunked write → partial-tail window
+					mid := len(obj) / 2
+					_, _ = f.WriteString(obj[:mid])
+					_, _ = f.WriteString(obj[mid:] + sep)
+				} else {
+					_, _ = f.WriteString(obj + sep)
+				}
+				writeMu.Unlock()
+				written.Store(tid, struct{}{})
+				atomic.AddInt64(&writtenCount, 1)
+			}
+		}(w)
+	}
+	wg.Wait()
+	require.NoError(t, f.Close())
+
+	// Stop the concurrent reader, then do an authoritative final drain from 0.
+	close(stop)
+	readerWG.Wait()
+
+	var finalSeen sync.Map
+	var finalDupes int64
+	drainCount(path, 0, &finalSeen, &finalDupes)
+
+	seenCount := 0
+	finalSeen.Range(func(_, _ any) bool { seenCount++; return true })
+
+	assert.Equal(t, int64(0), finalDupes, "no entry decoded twice in a single drain")
+	assert.Equal(t, int(writtenCount), seenCount, "every written entry decoded exactly once")
+
+	// Cross-check: every written trans_id was seen.
+	missing := 0
+	written.Range(func(k, _ any) bool {
+		if _, ok := finalSeen.Load(k); !ok {
+			missing++
+		}
+		return true
+	})
+	assert.Equal(t, 0, missing, "no written trans_id missing from the decoded set")
+}
+
+// TestStream_TruncationRecovery verifies copytruncate handling: after the file is
+// truncated in place and new entries appended, the reader resets its offset and
+// processes the post-truncation entries without stalling.
+func TestStream_TruncationRecovery(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ops.log")
+
+	writeAll := func(flag int, tids ...string) {
+		f, err := os.OpenFile(path, flag|os.O_WRONLY, 0644)
+		require.NoError(t, err)
+		for _, tid := range tids {
+			_, _ = f.WriteString(entryJSON(tid)) // concatenated, no newline
+		}
+		require.NoError(t, f.Close())
+	}
+
+	var seen sync.Map
+	var dupes int64
+
+	// Phase 1: write + fully drain.
+	writeAll(os.O_CREATE|os.O_APPEND, "a1", "a2", "a3")
+	off := drainCount(path, 0, &seen, &dupes)
+
+	// Phase 2: copytruncate (shrink in place) + write new entries.
+	writeAll(os.O_TRUNC, "b1", "b2") // O_TRUNC empties then writes
+	off = drainCount(path, off, &seen, &dupes)
+	_ = off
+
+	for _, tid := range []string{"a1", "a2", "a3", "b1", "b2"} {
+		_, ok := seen.Load(tid)
+		assert.Truef(t, ok, "entry %s should have been processed across truncation", tid)
+	}
+	assert.Equal(t, int64(0), dupes, "no duplicates across truncation")
+}
+
+// TestProcessLogEntries_RealWrapper drives the actual processLogEntries against a
+// concatenated file and asserts it consumes the whole file (offset == size) with
+// metrics enabled and no auditor — the integration wiring, end to end.
+func TestProcessLogEntries_RealWrapper(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ops.log")
+
+	content := entryJSON("w1") + entryJSON("w2") + entryJSON("w3") // concatenated
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	cfg := OpsLogConfig{
+		LogFilePath:    path,
+		MaxLogFileSize: 0, // disable size rotation so rotateLogIfNeeded is a no-op
+		MetricsConfig:  MetricsConfig{TrackRequestsPerBucket: true},
+	}
+
+	newOffset, err := processLogEntries(cfg, nil, nil, NewMetrics(), nil, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(content)), newOffset, "whole concatenated file consumed")
+}


### PR DESCRIPTION
stream-decode ops log to handle concatenated RGW entries and stop the parse-error stdout storm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of ops-log streams containing concatenated JSON entries, even when entries lack newline separators.
  * Prevented incomplete log entries from being consumed, reducing the risk of lost or duplicated records during streaming and resumed processing.
  * Added recovery for malformed data and in-place log truncation.
  * Improved handling of anonymous requests and simplified optional pretty-printed stdout output.
* **Tests**
  * Added coverage for concurrent writes, partial entries, malformed data, truncation recovery, and exact-once processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->